### PR TITLE
dont match todos when occuring as code, fixes #8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * Only find newly introduced todos - hanneskaeufler
+* Don't find todos obviously occuring in code - hanneskaeufler
 
 ## 0.0.2
 

--- a/lib/todoist/diff_todo_finder.rb
+++ b/lib/todoist/diff_todo_finder.rb
@@ -1,7 +1,7 @@
 module Danger
   # Identify todos in a set of diffs
   class DiffTodoFinder
-    TODO_REGEXP = /\+.*TODO|FIXME/i
+    TODO_REGEXP = /\+.*(TODO|FIXME)[\s:]/i
 
     def find_diffs_containing_todos(diffs)
       diffs

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -5,13 +5,13 @@ module Danger
     let(:subject) { Danger::DiffTodoFinder.new }
 
     describe "#find_diffs_containing_todos" do
-      %w(TODO todo FIXME fixme).each do |marker|
+      %w(TODO TODO: todo todo: FIXME fixme FIXME: fixme).each do |marker|
         it "identifies a new '#{marker}' as a todo" do
           diffs = [
             Git::Diff::DiffFile.new(
               "base",
               path:  "some/file.rb",
-              patch: "+ TODO: some todo"
+              patch: "+ #{marker} some todo"
             )
           ]
 
@@ -33,6 +33,26 @@ module Danger
         todos = subject.find_diffs_containing_todos(diffs)
 
         expect(todos).to be_empty
+      end
+
+      [
+        "+ class TodosController",
+        "+ function foo(todo) {",
+        "+ def todo()"
+      ].each do |patch|
+        it "does not identify occurences in e.g. a new class name" do
+          diffs = [
+            Git::Diff::DiffFile.new(
+              "base",
+              path:  "some/file.rb",
+              patch: patch
+            )
+          ]
+
+          todos = subject.find_diffs_containing_todos(diffs)
+
+          expect(todos).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
```ruby
class TodoController
```
is now not marked as a todo anymore.