### PR TITLE
try to work around issue #22 by rejecting nils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* fixes crash when git returns nil - hanneskaeufler
+
 ## 1.1.0
 
 * add support for multiline comments - hanneskaeufler

--- a/lib/todoist/plugin.rb
+++ b/lib/todoist/plugin.rb
@@ -114,6 +114,7 @@ module Danger
 
     def diffs_of_interest
       files_of_interest
+        .compact
         .map { |file| git.diff_for_file(file) }
     end
   end

--- a/spec/todoist_spec.rb
+++ b/spec/todoist_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path("../spec_helper", __FILE__)
 
+# rubocop:disable Metrics/ModuleLength
 module Danger
   describe Danger::DangerTodoist do
     it "should be a plugin" do
@@ -120,6 +121,14 @@ PATCH
         expect(warnings).to be_empty
         expect(failures).to be_empty
         expect(markdowns).to be_empty
+      end
+
+      it "does not raise when git returns nil" do
+        invalid = [nil]
+        allow(@dangerfile.git).to receive(:modified_files).and_return(invalid)
+        allow(@dangerfile.git).to receive(:added_files).and_return([])
+
+        expect { @todoist.warn_for_todos }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
For some reason it appears there are nils creeping in through the git
plugin of danger. See
https://github.com/hanneskaeufler/danger-todoist/issues/22#issuecomment-262641835