### PR TITLE
allow to specify todo indicators in Dangerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* allow to specify todo keywords - hanneskaeufler
+
 ## 1.1.0
 
 * add support for multiline comments - hanneskaeufler

--- a/Dangerfile
+++ b/Dangerfile
@@ -10,7 +10,6 @@ unless git.modified_files.include?("CHANGELOG.md")
 end
 
 # Identify leftover todos
-todoist.keywords = ["BUG"]
 todoist.message = "There are still some things to do in this PR."
 todoist.warn_for_todos
 todoist.print_todos_table

--- a/Dangerfile
+++ b/Dangerfile
@@ -10,6 +10,7 @@ unless git.modified_files.include?("CHANGELOG.md")
 end
 
 # Identify leftover todos
+todoist.keywords = ["BUG"]
 todoist.message = "There are still some things to do in this PR."
 todoist.warn_for_todos
 todoist.print_todos_table

--- a/lib/todoist/diff_todo_finder.rb
+++ b/lib/todoist/diff_todo_finder.rb
@@ -1,7 +1,9 @@
 module Danger
   # Identify todos in a set of diffs
   class DiffTodoFinder
-    def initialize(keywords = %w(TODO FIXME))
+    DEFAULT_KEYWORDS = %w(TODO FIXME).freeze
+
+    def initialize(keywords)
       @keywords = keywords
     end
 

--- a/lib/todoist/diff_todo_finder.rb
+++ b/lib/todoist/diff_todo_finder.rb
@@ -1,21 +1,15 @@
 module Danger
   # Identify todos in a set of diffs
   class DiffTodoFinder
-    TODO_REGEXP = /
-      ^\+                 # we only look at additions, marked by + in diffs
-      \s*                 # followed by optional space
-      [^a-z0-9\+\s]+      # anything looking like a comment indicator
-      (\n\+)?             # allow multiline comment markers
-      \s+                 # followed by at least one space
-      (TODO|FIXME)        # our todo indicator
-      [\s:]{1}            # followed by a space or colon
-      (?<text>.*)$        # matching any text until the end of the line
-    /ix
+    def initialize(keywords = %w(TODO FIXME))
+      @keywords = keywords
+    end
 
     def find_diffs_containing_todos(diffs)
       todos = []
+      regexp = todo_regexp
       diffs.each do |diff|
-        matches = diff.patch.scan(TODO_REGEXP)
+        matches = diff.patch.scan(regexp)
         next if matches.empty?
 
         matches.each do |match|
@@ -23,6 +17,21 @@ module Danger
         end
       end
       todos
+    end
+
+    private
+
+    def todo_regexp
+      /
+      ^\+                 # we only look at additions, marked by + in diffs
+      \s*                 # followed by optional space
+      [^a-z0-9\+\s]+      # anything looking like a comment indicator
+      (\n\+)?             # allow multiline comment markers
+      \s+                 # followed by at least one space
+      (#{@keywords.join("|")})       # our todo indicator
+      [\s:]{1}            # followed by a space or colon
+      (?<text>.*)$        # matching any text until the end of the line
+    /ix
     end
   end
 end

--- a/lib/todoist/plugin.rb
+++ b/lib/todoist/plugin.rb
@@ -114,7 +114,7 @@ module Danger
     # BUG: what about empty array?
     def keywords
       return @keywords unless @keywords.nil?
-      %w(TODO FIXME)
+      Danger::DiffTodoFinder::DEFAULT_KEYWORDS
     end
 
     def message

--- a/lib/todoist/plugin.rb
+++ b/lib/todoist/plugin.rb
@@ -39,6 +39,13 @@ module Danger
     attr_writer :message
 
     #
+    # Keywords to recognize as todos
+    #
+    # @attr_writer [Array] keywords Custom array of strings to identify todos
+    # @return [void]
+    attr_writer :keywords
+
+    #
     # Adds a warning if there are todos found in the modified code
     #
     # @return [void]
@@ -100,7 +107,14 @@ module Danger
       @todos = []
       return if files_of_interest.empty?
 
-      @todos = DiffTodoFinder.new.find_diffs_containing_todos(diffs_of_interest)
+      @todos = DiffTodoFinder.new(keywords)
+                             .find_diffs_containing_todos(diffs_of_interest)
+    end
+
+    # BUG: what about empty array?
+    def keywords
+      return @keywords unless @keywords.nil?
+      %w(TODO FIXME)
     end
 
     def message

--- a/lib/todoist/plugin.rb
+++ b/lib/todoist/plugin.rb
@@ -111,7 +111,6 @@ module Danger
                              .find_diffs_containing_todos(diffs_of_interest)
     end
 
-    # BUG: what about empty array?
     def keywords
       return @keywords unless @keywords.nil?
       Danger::DiffTodoFinder::DEFAULT_KEYWORDS

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -2,7 +2,9 @@ require File.expand_path("../spec_helper", __FILE__)
 
 module Danger
   describe Danger::DiffTodoFinder do
-    let(:subject) { Danger::DiffTodoFinder.new }
+    let(:subject) do
+      Danger::DiffTodoFinder.new(Danger::DiffTodoFinder::DEFAULT_KEYWORDS)
+    end
 
     describe "#find_diffs_containing_todos" do
       %w(TODO TODO: todo todo: FIXME fixme FIXME: fixme).each do |marker|

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -15,6 +15,15 @@ module Danger
         end
       end
 
+      it "identifies todos with changed finder string" do
+        diff = sample_diff("+ # BUG some todo")
+
+        subject = described_class.new(["BUG"])
+        todos = subject.find_diffs_containing_todos([diff])
+
+        expect(todos).to_not be_empty
+      end
+
       # those comment indicators are ripped off https://github.com/pgilad/leasot
       %w(# {{ -- // /* <!-- <%# % / -# {{! {{!-- {# <%--).each do |comment|
         it "identifies todos in languages with '#{comment}' as comments" do

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -26,6 +26,15 @@ module Danger
         expect(todos).to_not be_empty
       end
 
+      it "doesnt crash but also doesnt find anything with empty keywords" do
+        diff = sample_diff("+ # BUG some todo")
+
+        subject = described_class.new([])
+        todos = subject.find_diffs_containing_todos([diff])
+
+        expect(todos).to be_empty
+      end
+
       # those comment indicators are ripped off https://github.com/pgilad/leasot
       %w(# {{ -- // /* <!-- <%# % / -# {{! {{!-- {# <%--).each do |comment|
         it "identifies todos in languages with '#{comment}' as comments" do

--- a/spec/todoist_spec.rb
+++ b/spec/todoist_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path("../spec_helper", __FILE__)
 
+# rubocop:disable Metrics/ModuleLength
 module Danger
   describe Danger::DangerTodoist do
     it "should be a plugin" do
@@ -61,6 +62,13 @@ PATCH
           @todoist.warn_for_todos
 
           expect(warnings).to eq(["changed message"])
+        end
+
+        it "allows the keywords to be changed" do
+          @todoist.keywords = ["find-nothing"]
+          @todoist.warn_for_todos
+
+          expect(warnings).to be_empty
         end
 
         it "can print a report, even without warning first" do


### PR DESCRIPTION
with `todoist.keywords = ["foo"]` you can specify a list of keywords to
indicate a todo/fixme item.