### PR TITLE
🤢 rescue from exceptions inside of the git gem, fixes #36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+rescue from exception in git gem - hanneskaeufler
+
 ## 1.2.1
 
 * fix issue #32 crash on nil - hanneskaeufler

--- a/lib/todoist/plugin.rb
+++ b/lib/todoist/plugin.rb
@@ -128,9 +128,26 @@ module Danger
     # into the files_of_interest. We have to make sure to only
     # try to look up diffs for actual filepaths (strings)
     def diffs_of_interest
-      files_of_interest
-        .select { |file| file.is_a?(String) }
-        .map { |file| git.diff_for_file(file) }
+      files_of_interest.map do |file|
+        diff = EmptyDiff.new
+        begin
+          diff = git.diff_for_file(file)
+        rescue
+          log_unable_to_find_diff(file.inspect)
+        end
+        diff
+      end
+    end
+
+    def log_unable_to_find_diff(file)
+      markdown("* danger-todoist was unable to determine diff for \"#{file}\".")
+    end
+  end
+
+  # Null object incase a diff cannot be determined
+  class EmptyDiff
+    def patch
+      ""
     end
   end
 end

--- a/spec/todoist_spec.rb
+++ b/spec/todoist_spec.rb
@@ -131,12 +131,21 @@ PATCH
         expect(markdowns).to be_empty
       end
 
-      it "does not raise when git returns nil" do
+      it "does not raise when git raises, but warns" do
         invalid = [nil, 0, false]
         allow(@dangerfile.git).to receive(:modified_files).and_return(invalid)
         allow(@dangerfile.git).to receive(:added_files).and_return(invalid)
 
         expect { @todoist.warn_for_todos }.to_not raise_error
+        expect(markdowns).to include(
+          "* danger-todoist was unable to determine diff for \"nil\"."
+        )
+        expect(markdowns).to include(
+          "* danger-todoist was unable to determine diff for \"0\"."
+        )
+        expect(markdowns).to include(
+          "* danger-todoist was unable to determine diff for \"false\"."
+        )
       end
     end
   end


### PR DESCRIPTION
I cannot reproduce this in real life, tests must come to the rescue.