### PR TITLE
Fix incorrect TODO matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Fix incorrect TODO matching - allewun
+
 ## 2.0.0
 
 * Drop rubies below 2.3.8 from support and require bundler 2 - hanneskaeufler

--- a/lib/todoist/diff_todo_finder.rb
+++ b/lib/todoist/diff_todo_finder.rb
@@ -10,8 +10,13 @@ module Danger
         .map do |diff|
           # Should only look for matches *within* the changed lines of a patch
           # (lines that begin with "+"), not the entire patch.
-          # The `todo_regexp` currently doesn't enforce this correctly in certain cases.
-          matches = MatchesInDiff::Patch.new(diff.patch).changed_lines.map(&:content).join.scan(@regexp)
+          # The current regexp doesn't enforce this correctly in some cases.
+          matches = MatchesInDiff::Patch.new(diff.patch)
+            .changed_lines
+            .map(&:content)
+            .join
+            .scan(@regexp)
+
           MatchesInDiff.new(diff, matches)
         end
         .select(&:todo_matches?)

--- a/lib/todoist/diff_todo_finder.rb
+++ b/lib/todoist/diff_todo_finder.rb
@@ -10,7 +10,7 @@ module Danger
         .map do |diff|
           # Should only look for matches *within* the changed lines of a patch
           # (lines that begin with "+"), not the entire patch.
-          # The @regexp currently doesn't enforce this correctly in certain cases.
+          # The `todo_regexp` currently doesn't enforce this correctly in certain cases.
           matches = MatchesInDiff::Patch.new(diff.patch).changed_lines.map(&:content).join.scan(@regexp)
           MatchesInDiff.new(diff, matches)
         end

--- a/lib/todoist/diff_todo_finder.rb
+++ b/lib/todoist/diff_todo_finder.rb
@@ -5,17 +5,18 @@ module Danger
       @regexp = todo_regexp(keywords)
     end
 
+    # rubocop:disable Metrics/MethodLength
     def call(diffs)
       diffs
         .map do |diff|
           # Should only look for matches *within* the changed lines of a patch
           # (lines that begin with "+"), not the entire patch.
           # The current regexp doesn't enforce this correctly in some cases.
-          matches = MatchesInDiff::Patch.new(diff.patch)
-            .changed_lines
-            .map(&:content)
-            .join
-            .scan(@regexp)
+          patch = MatchesInDiff::Patch.new(diff.patch)
+          matches = patch.changed_lines
+                         .map(&:content)
+                         .join
+                         .scan(@regexp)
 
           MatchesInDiff.new(diff, matches)
         end
@@ -23,6 +24,7 @@ module Danger
         .map(&:all_todos)
         .flatten
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -140,6 +140,12 @@ PATCH
                    "I'd rather not have this here ... because it's probably "\
                    "just a bit of code that we can reimplement or steal"])
       end
+
+      it "ignores pre-existing todo strings found in the context lines of a patch" do
+        diff = sample_diff_fixture("preexisting_todo.diff")
+        todos = subject.call([diff])
+        expect(todos).to be_empty
+      end
     end
   end
   # rubocop:enable Metrics/BlockLength

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -141,7 +141,7 @@ PATCH
                    "just a bit of code that we can reimplement or steal"])
       end
 
-      it "ignores pre-existing todo strings found in the context lines of a patch" do
+      it "ignores pre-existing todo strings found in context lines of a patch" do
         diff = sample_diff_fixture("preexisting_todo.diff")
         todos = subject.call([diff])
         expect(todos).to be_empty

--- a/spec/diff_todo_finder_spec.rb
+++ b/spec/diff_todo_finder_spec.rb
@@ -141,7 +141,7 @@ PATCH
                    "just a bit of code that we can reimplement or steal"])
       end
 
-      it "ignores pre-existing todo strings found in context lines of a patch" do
+      it "ignores pre-existing todos found in the context lines of a patch" do
         diff = sample_diff_fixture("preexisting_todo.diff")
         todos = subject.call([diff])
         expect(todos).to be_empty

--- a/spec/fixtures/preexisting_todo.diff
+++ b/spec/fixtures/preexisting_todo.diff
@@ -1,0 +1,24 @@
+diff --git a/lib/todoist/diff_todo_finder.rb b/lib/todoist/diff_todo_finder.rb
+index b58809b..1ecc4f0 100644
+--- a/lib/todoist/diff_todo_finder.rb
++++ b/lib/todoist/diff_todo_finder.rb
+@@ -9,7 +9,6 @@ def initialize(keywords)
+ 
+     def call(diffs)
+       diffs
+-        .each { |diff| debug(diff) }
+         .map { |diff| MatchesInDiff.new(diff, diff.patch.scan(@regexp)) }
+         .select(&:todo_matches?)
+         .map(&:all_todos)
+@@ -54,9 +53,11 @@ def all_todos
+ 
+     def line_number(match)
+       _, todo_indicator = match
+       GitDiffParser::Patch.new(diff.patch).changed_lines.each do |line|
+         return line.number if line.content =~ /#{todo_indicator}/
+       end
++      # introducing a change with a newline right above a pre-existing TODO
++
+       # TODO: thats not gonna fly
+       -1
+     end

--- a/spec/fixtures/preexisting_todo.diff
+++ b/spec/fixtures/preexisting_todo.diff
@@ -2,14 +2,6 @@ diff --git a/lib/todoist/diff_todo_finder.rb b/lib/todoist/diff_todo_finder.rb
 index b58809b..1ecc4f0 100644
 --- a/lib/todoist/diff_todo_finder.rb
 +++ b/lib/todoist/diff_todo_finder.rb
-@@ -9,7 +9,6 @@ def initialize(keywords)
- 
-     def call(diffs)
-       diffs
--        .each { |diff| debug(diff) }
-         .map { |diff| MatchesInDiff.new(diff, diff.patch.scan(@regexp)) }
-         .select(&:todo_matches?)
-         .map(&:all_todos)
 @@ -54,9 +53,11 @@ def all_todos
  
      def line_number(match)


### PR DESCRIPTION
There's a bug with the regex used for TODO matching that accidentally captures TODOs that fall outside of the changed lines in a diff patch.

The regex _should not_ find any matches in these 2 patches, but the newline seems to throw things off (try [here](https://rubular.com/r/DPkoE2ztpn)):

✅ Regex works correctly here:
```diff
+      # introducing a change with no newline right above a pre-existing TODO
       # TODO: thats not gonna fly
```

❌ Regex works incorrectly here:
```diff
+      # introducing a change with a newline right above a pre-existing TODO
+
       # TODO: thats not gonna fly
```

I didn't have time to debug and fix the regex, so I called `scan(@regexp)` on the changed lines only, rather than the entire patch.